### PR TITLE
Remover as seções da SouJunior Talk

### DIFF
--- a/src/components/FooterDefault/index.tsx
+++ b/src/components/FooterDefault/index.tsx
@@ -67,15 +67,6 @@ const FooterDefault = () => {
                                 SouJunior Labs
                             </a>
                         </li>
-                        <li>
-                            <a
-                                href="https://discord.com/invite/564CDre9F3"
-                                rel="noreferrer"
-                                target="_blank"
-                            >
-                                SouJunior Talk
-                            </a>
-                        </li>
                     </ul>
                 </div>
                 <div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -119,12 +119,6 @@ export const Home: React.FC = () => {
                         Description="Seja mentorado por um profissional experiente."
                     />
                     <OurSitesCard
-                        Link="https://discord.com/invite/564CDre9F3"
-                        Title="SouJunior Talk"
-                        Img={Site}
-                        Description="Aprenda idiomas e aperfeiçoe-se!"
-                    />
-                    <OurSitesCard
                         Link="https://docs.google.com/forms/d/e/1FAIpQLSd1IspO3Hwylce2kHtIsmyBAkH7p3VFmdYUmdL75YXZ-DSNBA/viewform"
                         Title="SouJunior Labs"
                         Img={NosAcompanhe}

--- a/src/pages/styles/Home.styles.ts
+++ b/src/pages/styles/Home.styles.ts
@@ -291,7 +291,8 @@ export const OurSitesSection = styled.section`
     align-items: center;
     flex-direction: column;
     margin-top: 180px;
-    margin-bottom: 196px;
+    gap:24px;
+    margin-bottom: 89px;
 
     @media (max-width: 1000px) {
         margin: 80px 0 4.5rem;


### PR DESCRIPTION
Remover seções da SouJunior Talk - https://github.com/SouJunior/vagas-webapp/issues/344

## Descrição
Remoção das seções em que a SouJunior Talk aparece.
___
## Mudanças
Retirei as seções em que a SouJunior Talk aparece. Ela aparece na home e no footer

___
## Problemas Resolvidos
Com este pull request removo os links que levam a SouJunior Talk
___

## Prints
Antes :
![image](https://github.com/user-attachments/assets/11c6caa2-c2a7-4907-b2bb-edb165195807)
![image](https://github.com/user-attachments/assets/b6851cdf-bd6b-45cf-9bde-695d56ab67da)

Depois :
![image](https://github.com/user-attachments/assets/913c476c-0822-4fa4-8650-a8d67cfe853a)
![image](https://github.com/user-attachments/assets/774e85be-aee4-4f0e-886d-a384908bb1a7)

