### PR TITLE
Fix: Ajusta a responsividade e padrões do campo MainSearchFilter na home para torná-lo mais amigável ao usuário.

### DIFF
--- a/src/components/Home/HomeJobFilter/styles.ts
+++ b/src/components/Home/HomeJobFilter/styles.ts
@@ -7,26 +7,18 @@ export const FormWrapper = styled.div`
     justify-content: center;
     width: 100%;
 
+   
+
     @media (max-width: 568px) {
-        height: 37px;
+        
         position: relative;
-        top: 35px;
-        height: 37;
-        margin-top: 20px;
+        
+        
+        
         align-items: center;
         border-radius: 52px;
         border: 2px;
         padding: 2px 2px 2px 8px;
-    }
-
-
-
-    @media (max-width: 415px) {
-        position: relative;
-        top: 100px;
-    }
-    @media ${devices.mobileL} {
-        top: 80px;
     }
 
     @media ${devices.mobileM} {
@@ -46,7 +38,7 @@ export const FormWrapper = styled.div`
 `;
 
 export const Form = styled.form`
-    width: 100%;
+    width: 92%;
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -67,7 +59,7 @@ export const Form = styled.form`
 `;
 
 export const Input = styled.input`
-    width: 100%;
+    width: 80%;
     height: 58px;
     padding: 0 56px;
     color: #515151;
@@ -113,21 +105,24 @@ export const SearchButton = styled.button`
     max-width: 207px;
     opacity: 1;
     transition: all 0.2s;
+
     :hover {
-        opacity: 0.8;
+        background-color: ${({ theme }) => theme.colors.primaryLight};
     }
+
     @media ${devices.mobileL} {
         padding: 12px 0px;
         width: 50%;
     }
+
     @media ${devices.mobileM} {
         width: 70%;
     }
+
     @media ${devices.mobileS} {
         width: 100%;
         padding: 12px;
         font-size: 12px;
     }
-
 
 `;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -78,8 +78,8 @@ export const Home: React.FC = () => {
                         <Image src={ImageHome}></Image>
                     </MainSearchFilter>
                 </MainContent>
-                {/* <Circle src={circle} />
-                <CircleImage src={doubleCircles} /> */}
+                <Circle src={circle} />
+                <CircleImage src={doubleCircles} />
             </Main>
 
             <VocationalBannerArea>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -74,11 +74,12 @@ export const Home: React.FC = () => {
                             Mais de {filteredJobsCount} vagas disponíveis para
                             você!
                         </JobsInfo>
+                        
+                        <Image src={ImageHome}></Image>
                     </MainSearchFilter>
-                    <Image src={ImageHome}></Image>
                 </MainContent>
-                <Circle src={circle} />
-                <CircleImage src={doubleCircles} />
+                {/* <Circle src={circle} />
+                <CircleImage src={doubleCircles} /> */}
             </Main>
 
             <VocationalBannerArea>

--- a/src/pages/styles/Home.styles.ts
+++ b/src/pages/styles/Home.styles.ts
@@ -88,9 +88,7 @@ export const Title = styled.h2`
         font-weight: 700;
     }
 
-    @media (max-width: 1024px) {
-        width: 95%;
-    }
+    
 
     @media (max-width: 568px) {
         font-size: 2rem;
@@ -158,7 +156,6 @@ export const Image = styled.img`
     @media (max-width: 1024px) {
         position: relative;
         width: 40%;
-        left: 10%;
         margin-bottom: 2rem;
     }
 

--- a/src/pages/styles/Home.styles.ts
+++ b/src/pages/styles/Home.styles.ts
@@ -13,78 +13,74 @@ export const Main = styled.main`
     background-color: ${({ theme }) => theme.colors.primary};
     text-align: center;
 
-    @media (max-width: 1000px) {
+    @media (max-width: 1024px) {
         height: auto;
+        padding-top: 80px;
+        flex-direction: column;
+        gap: 32px;
     }
 
-    @media (max-width: 375px) {
-        width: 392px;
-        height: 700px;
+    @media (max-width: 768px) {
+        padding-top: 60px;
     }
 
     @media (max-width: 568px) {
-        height: 800px;
-    }
-
-    @media ${devices.mobileS} {
-        height: 470px; 
+        padding-top: 40px;
+        height: auto;
         width: 100%;
-
+        gap: 24px;
     }
 
-
+    @media (max-width: 375px) {
+        padding-top: 20px;
+        width: 100%;
+    }
 `;
 
 export const MainContent = styled.div`
     width: 100%;
     max-width: 1400px;
-    position: relative;
     display: flex;
     align-items: center;
     height: 100%;
 
-    @media (max-width: 1000px) {
+    @media (max-width: 1024px) {
         height: auto;
-        flex-wrap: wrap;
         flex-direction: column;
-        padding-top: 90px;
         justify-content: space-between;
+        gap: 20px;
     }
 
-    @media (max-width: 375px) {
-        width: 375px;
-    }
-
-    @media ${devices.mobileS} {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
+    @media (max-width: 568px) {
+        padding: 0 16px;
+        gap: 16px;
     }
 `;
 
 export const MainSearchFilter = styled.div`
     display: flex;
     flex-direction: column;
-    gap: 16px;
-    margin-left: 60px;
+    align-items: center;
+    gap: 2.5rem;
     width: 60%;
 
-    @media (max-width: 1000px) {
-        margin-left: 0px;
-        align-items: center;
-        width: 100%;
+    margin: 1rem; // Margin para não grudar conteúdo nos cantos
+    
+    @media (max-width: 768px) {
+        width: 80%;
+        gap: 2rem;
+
+        margin-top: 5rem;
     }
 
     @media (max-width: 568px) {
-        height: 470px;
-        margin-top: 65px;
-        gap: 25px;
+        width: 100%;
+        gap: 1.5rem;
     }
 `;
 
 export const Title = styled.h2`
-    max-width: 920px;
+    max-width: 100%;
     font-weight: 300;
     font-size: 2.9rem;
 
@@ -92,29 +88,19 @@ export const Title = styled.h2`
         font-weight: 700;
     }
 
-    @media (max-width: 1000px) {
+    @media (max-width: 1024px) {
         width: 95%;
     }
 
     @media (max-width: 568px) {
-        height: 144px;
-        font-size: 40px;
+        font-size: 2rem;
+        line-height: 2.5rem;
     }
 
-    
     @media (max-width: 375px) {
-        font-size: 24px;
-        position: relative;
-    }
-
-    @media ${devices.mobileS} {
-        height: 144px;
-        font-size: 26px;
+        font-size: 1.6rem;
         line-height: 2rem;
-
     }
-
-    
 `;
 
 export const SecondaryTitle = styled.h3`
@@ -125,20 +111,18 @@ export const SecondaryTitle = styled.h3`
 
     @media (max-width: 780px) {
         width: 90%;
+        font-size: 36px;
     }
 
     @media (max-width: 568px) {
-        width: 272px;
-        height: 62px;
-        position: relative;
-        top: -40px;
-        font-size: 32px;
+        width: 80%;
+        font-size: 28px;
     }
 
     @media (max-width: 375px) {
-        position: relative;
-        top: -50px;
-    }    
+        width: 90%;
+        font-size: 24px;
+    }
 `;
 
 export const JobsInfo = styled.p`
@@ -146,87 +130,50 @@ export const JobsInfo = styled.p`
     font-size: 16px;
     line-height: 19px;
     max-width: 796px;
+    text-align: center;
 
-    @media (max-width: 1000px) {
-        margin-bottom: 80px;
+    @media (max-width: 1024px) {
+        font-size: 14px;
     }
 
     @media (max-width: 568px) {
-        position: relative;
-        width: 400px;
-        height: 10px;
-        top: 130px;
-        font-size: 14px;
-        align-items: center;
+        width: 90%;
+        font-size: 12px;
+        line-height: 1.5rem;
     }
 
     @media (max-width: 375px) {
-        position: relative;
-        left: -145px;
-        top: 40px;
-    }
-
-    @media (max-width: 415px) {
-        width: 174px;
-        height: 10px;
-        font-size: 8px;
-        align-items: center;
-    }
-
-    @media ${devices.mobileS} {
-        width: 320px;
-        font-size: 10px;
-        position: relative;
-        top: 0px;
-        left: 0px;
+        font-size: 11px;
+        line-height: 1.4rem;
     }
 `;
 
 export const Image = styled.img`
     width: 403px;
     position: absolute;
-    bottom: 0px;
+    
     right: 0px;
+    margin-bottom: 4rem;
 
-    @media (max-width: 1000px) {
+    @media (max-width: 1024px) {
         position: relative;
         width: 40%;
-        left: 11%;
+        left: 10%;
+        margin-bottom: 2rem;
     }
 
     @media (max-width: 750px) {
         width: 35%;
+        margin-bottom: 1.5rem;
     }
 
     @media (max-width: 568px) {
-        width: 160px;
-        height: 160px;
-        position: relative;
-        top: -70px;
-        margin-left: 30px;
-    }
-
-    @media (max-width: 375px) {
-        width: 200px;
-        position: relative;
-        bottom: 190px;
-        left: -190px;
+        display: none;
     }
 
     
-
-    @media (max-width: 415px) {
-        height: 170px;
-    }
-
-    @media ${devices.mobileS} {
-        width: 100px;
-        height: 100px;
-        position: relative;
-        top: -195px;
-        left: 0px; 
-    }
 `;
+
 
 export const Circle = styled.img`
     position: absolute;
@@ -250,7 +197,7 @@ export const CircleImage = styled.img`
         width:60%;
     }
     
-    @media(max-width: 1000px) {
+    @media(max-width: 1024px) {
         bottom: -2%;
         width: 60%;
     }
@@ -294,7 +241,7 @@ export const OurSitesSection = styled.section`
     gap:24px;
     margin-bottom: 89px;
 
-    @media (max-width: 1000px) {
+    @media (max-width: 1024px) {
         margin: 80px 0 4.5rem;
     }
 


### PR DESCRIPTION
Ajusta a responsividade e padrões do campo MainSearchFilter na home para torná-lo mais amigável ao usuário.

## Descrição
Ajustei a responsividade do layout, tornando as alturas flexíveis, padronizando larguras e espaçamentos, e adaptando
tamanhos de fonte para melhorar a leitura em telas menores. Também ajustei o display do componente Image e o integrei ao
MainSearchFilter para um layout mais coeso e amigável.
___
## Mudanças
- Ajustei a flexibilidade das Alturas: Ajustei as alturas para auto e removi valores fixos em resoluções menores, para garantir que
o conteúdo se ajuste melhor em telas menores.

- Padronizei larguras para 100% ou ajustei para percentuais menores em resoluções específicas. Adicionei padding para evitar
que o conteúdo fique colado nas bordas.

- Ajustei tamanhos de fontes para escalarem de forma mais natural em telas menores, facilitando a leitura.

- Padronizei gaps e alinhamentos para garantir que os elementos mantenham um layout coeso, mesmo em telas menores.

- Alterei o display do componente Image para none em display menores para melhorar a experiência do usuário.

- Acoplei o componente Image para dentro do MainSearchFilter para adicionar padrão de gap e melhorar o espaçamento dos
itens .

- Alterei a largura mínima de 1000 para 1024 para aplicar responsividade em tablests e ipads maiores.


___
## Problemas Resolvidos
Arruma a responsividade no componente MainSearchFilter da home em dispositivos de 1024px de largura a 375px de largura
___

![Celular](https://github.com/user-attachments/assets/48765b4a-5c19-489e-95cc-b690e8b9ba76)
![Desktop](https://github.com/user-attachments/assets/367a3ec0-2dfb-4504-b43d-851b61d1cb26)
![Tablet](https://github.com/user-attachments/assets/4b4c7540-d3e5-4c78-aa7c-b90b064a443b)
